### PR TITLE
Update code of conduct

### DIFF
--- a/code-of-conduct/index.md
+++ b/code-of-conduct/index.md
@@ -83,6 +83,16 @@ Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
 members of the project's leadership.
 
+## Maintainers
+
+This repository is currently maintained and moderated by:
+
+- Syed Azeem Akhter [LinkedIn](https://www.linkedin.com/in/azma/), [Facebook](https://www.facebook.com/azimeister)
+- Muneeb Khan [LinkedIn](https://www.linkedin.com/in/muneebjs/), [Facebook](https://www.facebook.com/muneebjs)
+- Saif Ul Islam [LinkedIn](https://www.linkedin.com/in/https://www.linkedin.com/in/saif-ul-islam-93786b187//), [Facebook](https://www.facebook.com/SaifUlIslam9820)
+
+Please free feel to reach out in case of questions, suggestions, ideas and any possible issues that may arise.
+
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,

--- a/code-of-conduct/index.md
+++ b/code-of-conduct/index.md
@@ -42,6 +42,11 @@ Remember,
 - Give more to this group than you take. Self-promotion, spam and irrelevant links aren't allowed.
 - Being part of this group requires mutual trust. Authentic, expressive discussions make groups great, but may also be sensitive and private. What's shared in the group should stay in the group.
 
+At the end of the day, do remember that this is a community github repository, unlike most developer and coding related repositories. That means,
+
+- The suggestions, ideas of people in the community is what keeps this repository well worth all the hard work.
+- Please feel free to open suggestions and follow the contributing guidelines to get started on how to contribute and give back to the repository
+
 ## Our Responsibilities
 
 Project maintainers are responsible for clarifying the standards of acceptable


### PR DESCRIPTION
Updates the code of conduct with the below changes,

1. Finalizes the `our standards` section with a reminder about being a repository that's for the community, instead like a repository for the generally coding projects
2. I was unsure if the maintainers section missing from code of conduct should be added, but it's a seperate commit, please free to ignore it if it doesn't make sense. I copy pasted it from the main root `index.md` because it seemed natural for a person to try and find the maintainers section in the code of conduct, instead in the root `index.md`